### PR TITLE
fix: Todo style in markdown cells

### DIFF
--- a/applications/Parkinson's Disease classification.ipynb
+++ b/applications/Parkinson's Disease classification.ipynb
@@ -302,10 +302,10 @@
   },
   {
    "source": [
-    "- [ ] TODO: Tune hyper parameters\n",
-    "- [ ] TODO: Plot correlations for data information\n",
-    "- [ ] TODO: Scatter plot for data information\n",
-    "- [ ] TODO: Reduce features dimension by feature selection\n",
+    "TODO: Tune hyper parameters\n",
+    "TODO: Plot correlations for data information\n",
+    "TODO: Scatter plot for data information\n",
+    "TODO: Reduce features dimension by feature selection\n",
     "\n"
    ],
    "cell_type": "markdown",


### PR DESCRIPTION
GitHub doesn't show todo in the correct format for markdown cells in jupyter notebooks